### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Chris Cinelli
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.0",
   "description": "Branded QRcode generation",
   "author": "Chris Cinelli",
+  "license" : "MIT",
   "keywords": [
     "images",
     "logo",


### PR DESCRIPTION
This PR would fix issue #2.

The license decision is, of course, the area of responsibility of the original author.
As there was no feedback regarding the undefined license question, this PR is a suggestion to use the MIT license for this module.
Here is an overview of the MIT license: https://tldrlegal.com/license/mit-license

@ChrisCinelli If you agree with this license suggestion, we would be happy if you could merge this PR.

Thanks in advance,
Harald